### PR TITLE
[ja] Use new i18n keys (-vanilla and -k2) for the description of silica-processing

### DIFF
--- a/locale/ja/silicon.cfg
+++ b/locale/ja/silicon.cfg
@@ -27,9 +27,9 @@ fiber-optics=繊維光学
 gyro=微小電気機械システム(MEMS)
 
 [technology-description]
-silica-processing=石レンガを加工して珪砂を得ることができます。
-silica-processing-vanilla=
-silica-processing-k2=
+silica-processing=
+silica-processing-vanilla=__ITEM__stone-brick__を加工して__ITEM__silica__を得ることができます。
+silica-processing-k2=__ITEM__quartz__を加工して__ITEM__silica__を得ることができます。
 silicon-processing=珪砂を加工してシリコンを得ることができます。
 fiber-optics=回路ネットワークに光ファイバーを使用できるようになります。
 gyro=極小の可動電子機器について学びます。


### PR DESCRIPTION
Now the description of silica processing will refer correct ingredient with active mod loadout, thanks!

Without K2
<img width="301" alt="Silica Processing without K2 uses stone brick(石レンガ)" src="https://user-images.githubusercontent.com/10973/210138610-8810e6b3-4062-4a0e-b31f-e1424354db6a.png">

With K2
<img width="280" alt="Silica Processing without K2 uses quartz(石英)" src="https://user-images.githubusercontent.com/10973/210138638-c6ce0470-6637-4092-a6d8-1bceec1b6cc2.png">


